### PR TITLE
Fix #6: replace MKDir with ForceDirectories for subdirectory paths

### DIFF
--- a/Beta/D2Bridge Framework/D2Bridge.HTML.pas
+++ b/Beta/D2Bridge Framework/D2Bridge.HTML.pas
@@ -35,7 +35,7 @@ unit D2Bridge.HTML;
 interface
 
 uses
-  Classes, Generics.Collections,
+  Classes, Generics.Collections, StrUtils,
   System.UITypes;
 
 type
@@ -270,8 +270,13 @@ end;
 function TD2BridgeHTML.HTMLRender.MakeHTML: TStringList;
 var _Title: String;
     vBackGroundColor: string;
+    LPathCSS: String;
+    LPathJS: String;
 begin
  Result:= TStringList.Create;
+
+ LPathCSS := ReplaceStr( TD2BridgeClass( FD2BridgeHTML.FD2BridgeBaseClass ).D2BridgeManager.Prism.Options.PathCSS, '\', '/' );
+ LPathJS  := ReplaceStr( TD2BridgeClass( FD2BridgeHTML.FD2BridgeBaseClass ).D2BridgeManager.Prism.Options.PathJS, '\', '/' );
 
  _Title:= Title;
  if _Title = '' then
@@ -314,7 +319,8 @@ begin
     //Result.add('<link href="https://cdnjs.cloudflare.com/ajax/libs/free-jqgrid/4.15.5/css/ui.jqgrid.min.css" rel="stylesheet" type="text/css"/>');
     //Result.add('<link rel="stylesheet" type="text/css" href="css/ui.jqgrid-bootstrap5.css"/>');
     if FD2BridgeHTML.Options.IncluseBootStrap then
-    Result.add('<link rel="stylesheet" type="text/css" href="css/bootstrap.min.css"/>');
+    Result.add('<link rel="stylesheet" type="text/css" href="' + LPathCSS + '/bootstrap.min.css"/>');
+    //Result.add('<link rel="stylesheet" type="text/css" href="css/bootstrap.min.css"/>');
     //Result.add('<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.6.2/dist/css/bootstrap.min.css">');
     //Result.add('<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-rbsA2VBKQhggwzxH7pPCaAqO46MgnOM80zW1RWuH61DGLwZJEdK2Kadq2F9CUG65" crossorigin="anonymous"> ');
     //Result.add('<script src="https://cdnjs.cloudflare.com/ajax/libs/free-jqgrid/4.15.5/jquery.jqgrid.min.js"></script>');
@@ -353,7 +359,8 @@ begin
   Result.add('</div>');
   if FD2BridgeHTML.Options.FIncluseBootStrap then
   begin
-   Result.Add('<script src="js/bootstrap.bundle.min.js"></script>');
+   Result.Add('<script src="' + LPathJS + '/bootstrap.bundle.min.js"></script>');
+//   Result.Add('<script src="js/bootstrap.bundle.min.js"></script>');
   end;
   //Result.add('<script src="https://cdn.jsdelivr.net/npm/sweetalert2@11"></script>');
 

--- a/Beta/D2Bridge Framework/Prism/Prism.BaseClass.pas
+++ b/Beta/D2Bridge Framework/Prism/Prism.BaseClass.pas
@@ -1148,16 +1148,16 @@ begin
    FPrismLog:= TPrismLog.Create(FPrismOptions.LogFile, FPrismOptions.LogFileMode = lfmDaily);
 
   if not DirectoryExists(Options.RootDirectory) then
-  MkDir(Options.RootDirectory);
+  ForceDirectories(Options.RootDirectory);
 
   if not DirectoryExists(Options.RootDirectory + PrismBaseClass.Options.PathCSS) then
-  MkDir(Options.RootDirectory + PrismBaseClass.Options.PathCSS);
+  ForceDirectories(Options.RootDirectory + PrismBaseClass.Options.PathCSS);
 
   if not DirectoryExists(Options.RootDirectory + PrismBaseClass.Options.PathJS) then
-  MkDir(Options.RootDirectory + PrismBaseClass.Options.PathJS);
+  ForceDirectories(Options.RootDirectory + PrismBaseClass.Options.PathJS);
 
   if not DirectoryExists(Options.RootDirectory + PrismBaseClass.Options.PathFont) then
-  MkDir(Options.RootDirectory + PrismBaseClass.Options.PathFont);
+  ForceDirectories(Options.RootDirectory + PrismBaseClass.Options.PathFont);
 
   if not DirectoryExists(Options.RootDirectory + Options.PathTemp) then
    ForceDirectories(Options.RootDirectory + Options.PathTemp);
@@ -1172,7 +1172,7 @@ begin
    {$ENDIF}
   end;
   if not DirectoryExists(Options.RootDirectory + Options.PathTempSessions) then
-  MkDir(Options.RootDirectory + Options.PathTempSessions);
+  ForceDirectories(Options.RootDirectory + Options.PathTempSessions);
 
   //Expand Files Support
  {$IFDEF D2BRIDGE}

--- a/Beta/D2Bridge Framework/Prism/Prism.Server.HTML.Headers.dfm
+++ b/Beta/D2Bridge Framework/Prism/Prism.Server.HTML.Headers.dfm
@@ -1,4 +1,5 @@
 object PrismServerHTMLHeaders: TPrismServerHTMLHeaders
+  OldCreateOrder = True
   Height = 504
   Width = 779
 end

--- a/Beta/D2Bridge Framework/Prism/Prism.Server.HTML.Headers.pas
+++ b/Beta/D2Bridge Framework/Prism/Prism.Server.HTML.Headers.pas
@@ -35,7 +35,7 @@ unit Prism.Server.HTML.Headers;
 interface
 
 uses
-  Classes, Generics.Collections, SysUtils, DateUtils, Rtti,
+  Classes, Generics.Collections, SysUtils, DateUtils, Rtti, StrUtils,
   Prism.Interfaces, Prism.Types, Prism.Session, Prism.Server.HTTP.Commom;
 
 
@@ -248,8 +248,8 @@ function TPrismServerHTMLHeaders.AddHeadsIncludes(var HTMLText: string; host: st
 var
  FPathJS, FPathCSS: string;
 begin
- FPathJS:= PrismBaseClass.Options.PathJS;
- FPathCSS:= PrismBaseClass.Options.PathCSS;
+ FPathJS  := ReplaceStr( PrismBaseClass.Options.PathJS, '\', '/' );
+ FPathCSS := ReplaceStr( PrismBaseClass.Options.PathCSS, '\', '/' );
 
  Result:= '';
 
@@ -374,8 +374,8 @@ function TPrismServerHTMLHeaders.AddVariables(Session: IPrismSession): string;
 var
  FPathJS, FPathCSS: string;
 begin
- FPathJS:= PrismBaseClass.Options.PathJS;
- FPathCSS:= PrismBaseClass.Options.PathCSS;
+ FPathJS  := ReplaceStr( PrismBaseClass.Options.PathJS, '\', '/' );
+ FPathCSS := ReplaceStr( PrismBaseClass.Options.PathCSS, '\', '/' );
 
  Result:= FCoreVariable;
 
@@ -569,8 +569,8 @@ var
  HTMLCodeString: TStringList;
  FPathJS, FPathCSS: string;
 begin
- FPathJS:= PrismBaseClass.Options.PathJS;
- FPathCSS:= PrismBaseClass.Options.PathCSS;
+ FPathJS  := ReplaceStr( PrismBaseClass.Options.PathJS, '\', '/' );
+ FPathCSS := ReplaceStr( PrismBaseClass.Options.PathCSS, '\', '/' );
 
  HTMLCodeString:= TStringList.Create;
 


### PR DESCRIPTION
Fixes #6
Replaces MKDir with ForceDirectories to support nested asset paths (assets/js, assets/css).
Tested on Delphi and Lazarus.