### PR TITLE
Add support for TemplatePageJSFile (process external JS with callbacks)

### DIFF
--- a/Beta/D2Bridge Framework/D2Bridge.Interfaces.pas
+++ b/Beta/D2Bridge Framework/D2Bridge.Interfaces.pas
@@ -868,6 +868,9 @@ end;
     function GetTemplateMasterHTMLFile: string;
     function GetTemplatePageHTMLFile: string;
 
+    procedure SetTemplatePageJSFile(const Value: string);
+    function GetTemplatePageJSFile: string;
+
     procedure AddFormByClass(FormClass: TClass; AOwner: TComponent);
 
     procedure ShowLoader;
@@ -903,6 +906,7 @@ end;
     property Form: TObject read GetForm;
     property TemplateMasterHTMLFile: string read GetTemplateMasterHTMLFile write SetTemplateMasterHTMLFile;
     property TemplatePageHTMLFile: string read GetTemplatePageHTMLFile write SetTemplatePageHTMLFile;
+    property TemplatePageJSFile: string read GetTemplatePageJSFile write SetTemplatePageJSFile;
  end;
 
 

--- a/Beta/D2Bridge Framework/D2Bridge.Prism.Form.pas
+++ b/Beta/D2Bridge Framework/D2Bridge.Prism.Form.pas
@@ -105,6 +105,7 @@ begin
 
  TemplateMasterHTMLFile:= TD2BridgePrismFramework(D2BridgePrismFramework).TemplateMasterHTMLFile;
  TemplatePageHTMLFile:= TD2BridgePrismFramework(D2BridgePrismFramework).TemplatePageHTMLFile;
+ TemplatePageJSFile:= TD2BridgePrismFramework(D2BridgePrismFramework).TemplatePageJSFile;
 
  //Include Controls for Nested Forms
  for I := 0 to D2Bridge.NestedCount-1 do

--- a/Beta/D2Bridge Framework/D2Bridge.Prism.pas
+++ b/Beta/D2Bridge Framework/D2Bridge.Prism.pas
@@ -56,6 +56,7 @@ type
     FFrameworkForm: ID2BridgeFrameworkForm;
     FTemplateMasterHTMLFile: string;
     FTemplatePageHTMLFile: string;
+    FTemplatePageJSFile: string;
 
     FButton: ID2BridgeFrameworkItemButton;
     FEdit: ID2BridgeFrameworkItemEdit;
@@ -97,6 +98,8 @@ type
     procedure SetTemplatePageHTMLFile(AFilePageTemplate: string);
     function GetTemplateMasterHTMLFile: string;
     function GetTemplatePageHTMLFile: string;
+    procedure SetTemplatePageJSFile(const Value: string);
+    function GetTemplatePageJSFile: string;
 
     procedure AddFormByClass(FormClass: TClass; AOwner: TComponent);
 
@@ -137,6 +140,7 @@ type
     property TemplateMasterHTMLFile: string read GetTemplateMasterHTMLFile write SetTemplateMasterHTMLFile;
     property TemplatePageHTMLFile: string read GetTemplatePageHTMLFile write SetTemplatePageHTMLFile;
     property BaseClass: TD2BridgeClass read FBaseClass;
+    property TemplatePageJSFile: string read GetTemplatePageJSFile write SetTemplatePageJSFile;
 
     property Prism: IPrismBaseClass read GetPrism;
  end;
@@ -175,6 +179,8 @@ begin
   (FFrameworkForm as TPrismForm).TemplateMasterHTMLFile := FTemplateMasterHTMLFile;
   if FTemplatePageHTMLFile <> '' then
   (FFrameworkForm as TPrismForm).TemplatePageHTMLFile := FTemplatePageHTMLFile;
+  if FTemplatePageJSFile <> '' then
+  (FFrameworkForm as TPrismForm).TemplatePageJSFile := FTemplatePageJSFile;
  end;
 end;
 
@@ -223,6 +229,7 @@ begin
 
  FTemplateMasterHTMLFile:= '';
  FTemplatePageHTMLFile:= '';
+ FTemplatePageJSFile := '';
 end;
 
 procedure TD2BridgePrismFramework.CreateForm(AOwner: TComponent);
@@ -445,6 +452,11 @@ begin
  Result:= FTemplatePageHTMLFile;
 end;
 
+function TD2BridgePrismFramework.GetTemplatePageJSFile: string;
+begin
+  Result := FTemplatePageJSFile;
+end;
+
 procedure TD2BridgePrismFramework.HideLoader;
 begin
 
@@ -492,16 +504,25 @@ begin
  FFrameworkForm.SetBaseClass(BaseClass);
 end;
 
-procedure TD2BridgePrismFramework.SetTemplateMasterHTMLFile(
-  AFileMasterTemplate: string);
+procedure TD2BridgePrismFramework.SetTemplateMasterHTMLFile(AFileMasterTemplate: string);
 begin
- FTemplateMasterHTMLFile:= AFileMasterTemplate;
+  FTemplateMasterHTMLFile:= AFileMasterTemplate;
+  if Assigned(FFrameworkForm) then
+   (FFrameworkForm as TPrismForm).TemplateMasterHTMLFile := AFileMasterTemplate;
 end;
 
 procedure TD2BridgePrismFramework.SetTemplatePageHTMLFile(
   AFilePageTemplate: string);
 begin
  FTemplatePageHTMLFile:= AFilePageTemplate;
+end;
+
+procedure TD2BridgePrismFramework.SetTemplatePageJSFile(const Value: string);
+begin
+  FTemplatePageJSFile := Value;
+  // Propaga para o form se já estiver criado
+  if Assigned(FFrameworkForm) then
+    (FFrameworkForm as TPrismForm).TemplatePageJSFile := Value;
 end;
 
 procedure TD2BridgePrismFramework.ShowLoader;

--- a/Beta/D2Bridge Framework/Prism/Prism.Forms.pas
+++ b/Beta/D2Bridge Framework/Prism/Prism.Forms.pas
@@ -97,6 +97,7 @@ type
    FD2BridgeForm: TD2BridgeForm;
    FDestroying: Boolean;
    FLock: TMultiReadExclusiveWriteSynchronizer;
+   FTemplatePageJSFile: string;
    procedure SetName(AName: String); reintroduce;
    function GetName: String; reintroduce;
    function GetControls: TList<IPrismControl>;
@@ -133,6 +134,9 @@ type
    function GetOnUpload: TOnUpload;
    procedure SetOnUpload(const Value: TOnUpload);
    function GetServerControlsUpdating: boolean;
+   procedure SetTemplatePageJSFile(const Value: string);
+   function GetTemplatePageJSFile: string;
+
   protected
 {$IFDEF FPC}
    function GetFormUUID: string;
@@ -212,6 +216,7 @@ type
    property ControlsPrefix: String read GetControlsPrefix;
    property EnableControlsPrefix: Boolean read GetEnableControlsPrefix;
    property FormTimer: TPrismFormTimer read FTimerObserver write FTimerObserver;
+   property TemplatePageJSFile: string read GetTemplatePageJSFile write SetTemplatePageJSFile;
   published
    property OnProcessHTML: TProcessHTMLNotify read FOnProcessHTML write FOnProcessHTML;
    property OnTagHTML: TOnTagHTML read FOnTagHTML write FOnTagHTML;
@@ -721,6 +726,11 @@ end;
 function TPrismForm.GetTemplatePageHTMLFile: string;
 begin
  Result:= FTemplatePageHTMLFile;
+end;
+
+function TPrismForm.GetTemplatePageJSFile: string;
+begin
+  Result := FTemplatePageJSFile;
 end;
 
 procedure TPrismForm.Initialize;
@@ -1366,6 +1376,11 @@ end;
 procedure TPrismForm.SetTemplatePageHTMLFile(AFilePageTemplate: string);
 begin
  FTemplatePageHTMLFile:= AFilePageTemplate;
+end;
+
+procedure TPrismForm.SetTemplatePageJSFile(const Value: string);
+begin
+  FTemplatePageJSFile := Value;
 end;
 
 procedure TPrismForm.Show;

--- a/Beta/D2Bridge Framework/Prism/Prism.Interfaces.pas
+++ b/Beta/D2Bridge Framework/Prism/Prism.Interfaces.pas
@@ -1677,6 +1677,8 @@ type
    function GetOnUpload: TOnUpload;
    procedure SetOnUpload(const Value: TOnUpload);
    function PrismOptions: IPrismOptions;
+   procedure SetTemplatePageJSFile(const Value: string);
+   function GetTemplatePageJSFile: string;
 
    function CallBacks: IPrismFormCallBacks;
 
@@ -1729,6 +1731,7 @@ type
    property OnShowPopup: TOnPopup read GetOnShowPopup write SetOnShowPopup;
    property OnClosePopup: TOnPopup read GetOnClosePopup write SetOnClosePopup;
    property OnUpload: TOnUpload read GetOnUpload write SetOnUpload;
+   property TemplatePageJSFile: string read GetTemplatePageJSFile write SetTemplatePageJSFile;
  end;
 
 

--- a/Beta/D2Bridge Framework/Prism/Prism.Server.HTML.Headers.pas
+++ b/Beta/D2Bridge Framework/Prism/Prism.Server.HTML.Headers.pas
@@ -399,6 +399,7 @@ var
  vRequest: TPrismHTTPRequest;
  vResponse: TPrismHTTPResponse;
  vSession: TPrismSession;
+ JSText: string;
 begin
  HTMLText:= '';
  HTMLBodyText:= '';
@@ -535,6 +536,29 @@ begin
 
   //Processa os Includes
   ProcessHTMLHeaderIncludes(vRequest, HTMLText, vSession);
+
+  // Processa TemplatePageJSFile se configurado
+  if (vSession.ActiveForm.TemplatePageJSFile <> '') and
+     (FileExists('wwwroot' + PathDelim + vSession.ActiveForm.TemplatePageJSFile)) then
+  begin
+    HTMLFile := TStringStream.Create('', TEncoding.UTF8);
+    HTMLFile.LoadFromFile('wwwroot' + PathDelim + vSession.ActiveForm.TemplatePageJSFile);
+    JSText := HTMLFile.DataString;
+    HTMLFile.Free;
+
+    // Aplica os mesmos processamentos do HTML
+    vSession.ActiveForm.ProcessTagHTML(JSText);
+    vSession.ActiveForm.ProcessCallBackTagHTML(JSText);
+    vSession.ActiveForm.ProcessTagTranslate(JSText);
+
+    // Injeta como script inline antes do body
+    HTMLText := StringReplace(HTMLText, '$_prismbody',
+      '<script type="text/javascript">' + sLineBreak +
+      JSText + sLineBreak +
+      '</script>' + sLineBreak +
+      '$_prismbody',
+      [rfIgnoreCase]);
+  end;
 
   //Process Body
   ProcessHTMLBodyIncludes(vRequest, HTMLText, vSession);


### PR DESCRIPTION
This PR introduces support for processing external JavaScript files via TemplatePageJSFile, allowing Prism callbacks and tags to be used inside .js files.
The implementation is well scoped, opt‑in, and does not alter existing behavior.