### PR TITLE
fix(core): atualiza o rowNum ao recarregar dados do jqGrid

### DIFF
--- a/Beta/D2Bridge Framework/Prism/Prism.Grid.pas
+++ b/Beta/D2Bridge Framework/Prism/Prism.Grid.pas
@@ -347,7 +347,7 @@ begin
   '  }' +
   '  try{' +
   '   grid.jqGrid("clearGridData")' +
-  '   .jqGrid("setGridParam", { data: d2bridgeGridData, datatype: "local" })' +
+  '   .jqGrid("setGridParam", { data: d2bridgeGridData, datatype: "local", rowNum: ' + IntToStr(FRecordsPerPage) + ' })' +
   '   .trigger("reloadGrid", { page: 1 });' +
   '   if((d2bridgeGridData.length === 0) || (grid.jqGrid("getDataIDs").length > 0)){' +
   '    d2bridgeGridLog("reload concluido com " + grid.jqGrid("getDataIDs").length + " linhas");' +

--- a/README
+++ b/README
@@ -15,7 +15,7 @@ São Paulo - Brazil
 
 ## Version
 Beta (LGPL 2.1 License)
-- D2Bridge Framework 2.5.79
+- D2Bridge Framework 2.5.80
 
 Stable
 - D2Bridge Framework 2.0.8


### PR DESCRIPTION
Ao alterar RecordsPerPage de um DBGrid em runtime e chamar UpdateD2BridgeControl, a grade recarregava os dados mas continuava exibindo a quantidade antiga de linhas por página. Isso ocorria porque ClientGridReloadDataJS emitia setGridParam({ data, datatype: "local" }) sem incluir rowNum, fazendo o jqGrid ignorar o novo valor de FRecordsPerPage.