### PR TITLE
Ajustes no Prism: correção de eventos OnChange e remoção de UpdateControls

### DIFF
--- a/Beta/D2Bridge Framework/D2Bridge.Interfaces.pas
+++ b/Beta/D2Bridge Framework/D2Bridge.Interfaces.pas
@@ -600,6 +600,8 @@ end;
   ['{8F938440-5B4A-493E-B9D4-2A6874318F45}']
    procedure SetProcGetItems(AProc: TOnGetStrings);
    function GetProcGetItems: TOnGetStrings;
+   procedure SetProcGetValues(AProc: TOnGetStrings);
+   function GetProcGetValues: TOnGetStrings;
    function GetProcGetCaption: TOnGetValue;
    function GetProcSetCaption: TOnSetValue;
    procedure SetProcGetCaption(const Value: TOnGetValue);
@@ -612,6 +614,7 @@ end;
    function Dataware : ID2BridgeDatawareDataSource;
 
    property ProcGetItems: TOnGetStrings read GetProcGetItems write SetProcGetItems;
+   property ProcGetValues: TOnGetStrings read GetProcGetValues write SetProcGetValues;
    property ProcGetCaption: TOnGetValue read GetProcGetCaption write SetProcGetCaption;
    property ProcSetCaption: TOnSetValue read GetProcSetCaption write SetProcSetCaption;
    property ProcGetColumns: TOnGetValue read GetProcGetColumns write SetProcGetColumns;

--- a/Beta/D2Bridge Framework/D2Bridge.Manager.pas
+++ b/Beta/D2Bridge Framework/D2Bridge.Manager.pas
@@ -366,7 +366,7 @@ end;
 
 class function TD2BridgeManager.Version: string;
 begin
- Result:= '2.5.81'; //Version of D2Bridge Framework
+ Result:= '2.5.82'; //Version of D2Bridge Framework
 end;
 
 end.

--- a/Beta/D2Bridge Framework/D2Bridge.Prism.DBRadioGroup.pas
+++ b/Beta/D2Bridge Framework/D2Bridge.Prism.DBRadioGroup.pas
@@ -42,13 +42,17 @@ type
  PrismDBRadioGroup = class(TD2BridgePrismItem, ID2BridgeFrameworkItemDBRadioGroup)
   private
    FProcGetItems: TOnGetStrings;
+   FProcGetValues: TOnGetStrings;
    FProcSetCaption: TOnSetValue;
    FProcGetCaption: TOnGetValue;
    FProcSetColumns: TOnSetValue;
    FProcGetColumns: TOnGetValue;
    FD2BridgeDatawareDataSource: TD2BridgeDatawareDataSource;
    procedure SetProcGetItems(AProc: TOnGetStrings);
+   procedure SetProcGetValues(AProc: TOnGetStrings);
    function GetProcGetItems: TOnGetStrings;
+   function GetProcGetValues: TOnGetStrings;
+
    function GetProcGetCaption: TOnGetValue;
    function GetProcSetCaption: TOnSetValue;
    procedure SetProcGetCaption(const Value: TOnGetValue);
@@ -70,6 +74,7 @@ type
    function Dataware : ID2BridgeDatawareDataSource;
 
    property ProcGetItems: TOnGetStrings read GetProcGetItems write SetProcGetItems;
+   property ProcGetValues: TOnGetStrings read GetProcGetValues write SetProcGetValues;
    property ProcGetCaption: TOnGetValue read GetProcGetCaption write SetProcGetCaption;
    property ProcSetCaption: TOnSetValue read GetProcSetCaption write SetProcSetCaption;
    property ProcGetColumns: TOnGetValue read GetProcGetColumns write SetProcGetColumns;
@@ -89,6 +94,7 @@ begin
  inherited;
 
  FProcGetItems:= nil;
+ FProcGetValues:= nil;
  FProcGetCaption:= nil;
  FProcSetCaption:= nil;
  FProcGetColumns:= nil;
@@ -135,6 +141,11 @@ begin
  result:= FProcGetItems;
 end;
 
+function PrismDBRadioGroup.GetProcGetValues: TOnGetStrings;
+begin
+ result:= FProcGetValues;
+end;
+
 function PrismDBRadioGroup.GetProcSetCaption: TOnSetValue;
 begin
  result:= FProcSetCaption;
@@ -171,6 +182,9 @@ begin
  if Assigned(FProcGetItems) then
  TPrismDBRadioGroup(NewObj).ProcGetItems:= FProcGetItems;
 
+  if Assigned(FProcGetValues) then
+ TPrismDBRadioGroup(NewObj).ProcGetValues:= FProcGetValues;
+
  if Assigned(FProcGetCaption) then
  TPrismDBRadioGroup(NewObj).ProcGetCaption:= FProcGetCaption;
 
@@ -198,6 +212,12 @@ procedure PrismDBRadioGroup.SetProcGetItems(AProc: TOnGetStrings);
 begin
  FProcGetItems:= AProc;
 end;
+
+procedure PrismDBRadioGroup.SetProcGetValues(AProc: TOnGetStrings);
+begin
+ FProcGetValues :=  AProc;
+end;
+
 
 procedure PrismDBRadioGroup.SetProcSetCaption(const Value: TOnSetValue);
 begin

--- a/Beta/D2Bridge Framework/D2Bridge.VCLObj.TDBRadioGroup.pas
+++ b/Beta/D2Bridge Framework/D2Bridge.VCLObj.TDBRadioGroup.pas
@@ -53,6 +53,8 @@ type
    procedure TDBRadioGroupOnChange(EventParams: TStrings);
 
    function TDBRadioGroupProcGetItems: TStrings;
+   function TDBRadioGroupProcGetValues: TStrings;
+
    function TDBRadioGroupOnGetEnabled: Variant;
    procedure TDBRadioGroupOnSetEnabled(AValue: Variant);
    function TDBRadioGroupOnGetVisible: Variant;
@@ -142,6 +144,7 @@ begin
  TDBRadioGroup(FD2BridgeItemVCLObj.Item).DataField := '';
 
  FD2BridgeItemVCLObj.BaseClass.FrameworkExportType.DBRadioGroup.ProcGetItems := TDBRadioGroupProcGetItems;
+ FD2BridgeItemVCLObj.BaseClass.FrameworkExportType.DBRadioGroup.ProcGetValues := TDBRadioGroupProcGetValues;
  FD2BridgeItemVCLObj.BaseClass.FrameworkExportType.DBRadioGroup.GetEnabled := TDBRadioGroupOnGetEnabled;
  FD2BridgeItemVCLObj.BaseClass.FrameworkExportType.DBRadioGroup.SetEnabled := TDBRadioGroupOnSetEnabled;
  FD2BridgeItemVCLObj.BaseClass.FrameworkExportType.DBRadioGroup.GetVisible := TDBRadioGroupOnGetVisible;
@@ -215,6 +218,11 @@ end;
 function TVCLObjTDBRadioGroup.TDBRadioGroupProcGetItems: TStrings;
 begin
  Result := TDBRadioGroup(FD2BridgeItemVCLObj.Item).Items;
+end;
+
+function TVCLObjTDBRadioGroup.TDBRadioGroupProcGetValues: TStrings;
+begin
+ Result := TDBRadioGroup(FD2BridgeItemVCLObj.Item).Values;
 end;
 
 function TVCLObjTDBRadioGroup.VCLClass: TClass;

--- a/Beta/D2Bridge Framework/Prism/Prism.DBRadioGroup.pas
+++ b/Beta/D2Bridge Framework/Prism/Prism.DBRadioGroup.pas
@@ -35,7 +35,7 @@ unit Prism.DBRadioGroup;
 interface
 
 uses
- Classes, D2Bridge.JSON, SysUtils, StrUtils,
+ Classes, D2Bridge.JSON, SysUtils, StrUtils,  DB,
  Prism.Forms.Controls, Prism.Interfaces, Prism.Types, Prism.DataLink.Field,
  D2Bridge.Forms;
 
@@ -46,8 +46,10 @@ type
    FStoredColumns: integer;
    FStoredCaption: string;
    FStoredItems: TStrings;
+   FStoredValues: TStrings;
    FDataLinkField: TPrismDataLinkField;
    FProcGetItems: TOnGetStrings;
+   FProcGetValues: TOnGetStrings;
    FProcGetCaption: TOnGetValue;
    FProcSetCaption: TOnSetValue;
    FProcGetColumns: TOnGetValue;
@@ -55,6 +57,7 @@ type
    function GetCaption: string;
    procedure SetCaption(const Value: string);
    function GetItems: TStrings;
+   function GetValues: TStrings;
    function GetColumns: Integer;
    procedure SetColumns(const Value: Integer);
    function GroupNamed: string;
@@ -78,9 +81,11 @@ type
 
    property Caption: string read GetCaption write SetCaption;
    property Items: TStrings read GetItems;
+   property Values: TStrings read GetValues;
    property Columns: integer read GetColumns write SetColumns;
 
    property ProcGetItems: TOnGetStrings read FProcGetItems write FProcGetItems;
+   property ProcGetValues: TOnGetStrings read FProcGetValues write FProcGetValues;
    property ProcGetCaption: TOnGetValue read FProcGetCaption write FProcGetCaption;
    property ProcSetCaption: TOnSetValue read FProcSetCaption write FProcSetCaption;
    property ProcGetColumns: TOnGetValue read FProcGetColumns write FProcGetColumns;
@@ -99,6 +104,7 @@ begin
  inherited;
 
  FStoredItems:= TStringList.Create;
+ FStoredValues:= TStringList.Create;
 
  FDataLinkField:= TPrismDataLinkField.Create(Self);
  FDataLinkField.UseHTMLFormatSettings:= false;
@@ -113,6 +119,7 @@ destructor TPrismDBRadioGroup.Destroy;
 begin
  FDataLinkField.Free;
  FStoredItems.Free;
+ FStoredValues.Free;
 
  inherited;
 end;
@@ -147,6 +154,16 @@ begin
   Result:= FStoredItems;
 end;
 
+function TPrismDBRadioGroup.GetValues: TStrings;
+begin
+ if Assigned(ProcGetValues) then
+ begin
+  Result:= ProcGetValues;
+ end else
+  Result:= FStoredValues;
+end;
+
+
 function TPrismDBRadioGroup.GetReadOnly: Boolean;
 begin
  result:= Inherited;
@@ -167,6 +184,7 @@ begin
  FStoredSelectedItem:= DataWare.FieldText;
  FStoredCaption:= Caption;
  FStoredItems.CommaText:= Items.CommaText;
+ FStoredValues.CommaText:= Values.CommaText;
  FStoredColumns:= Columns;
 end;
 
@@ -183,6 +201,7 @@ end;
 procedure TPrismDBRadioGroup.ProcessComponentState(const ComponentStateInfo: TJSONObject);
 var
  vItemIndex: Integer;
+ vFieldValue : String;
 begin
  inherited;
 
@@ -193,12 +212,21 @@ begin
    begin
     if (vItemIndex >= 0) and (vItemIndex < Items.Count) then
     begin
-     DataWare.FieldValue:= Items[vItemIndex];
+
+     if (FStoredValues.Count = 0) then
+       vFieldValue        := Items[vItemIndex]
+     else
+       vFieldValue        := FStoredValues[vItemIndex];
+
+     DataWare.FieldValue:= vFieldValue;
      FStoredSelectedItem:= Items[vItemIndex];
     end else
     begin
-     DataWare.Field.Clear;
-     FStoredSelectedItem:= '';
+     if (DataWare.DataSet <> nil) and (DataWare.DataSet.State in dsEditModes) then
+     begin
+      DataWare.Field.Clear;
+      FStoredSelectedItem:= '';
+     end;
     end;
    end;
   end;
@@ -303,8 +331,10 @@ var
  NewSelectedItem, NewCaption: string;
  NewItems: TStrings;
  vItemIndex, NewColumns: integer;
+ vIndexValue : Integer;
 begin
- NewCaption:= Caption;
+ NewCaption  := Caption;
+ vIndexValue := 0;
  if NewCaption <> FStoredCaption then
  begin
   FStoredCaption:= NewCaption;
@@ -312,7 +342,17 @@ begin
   ScriptJS.Add('document.querySelector("[id='+LegendNamed+' i]").textContent = "'+  FStoredCaption +'";');
  end;
 
- NewSelectedItem := FDataLinkField.FieldText(AForceUpdate);
+ NewSelectedItem := '';
+ if (FStoredValues.Count = 0) then
+   NewSelectedItem := FDataLinkField.FieldText(AForceUpdate)
+ else
+ begin
+  vIndexValue     := FStoredValues.IndexOf(FDataLinkField.FieldText(AForceUpdate));
+  if (vIndexValue > -1)  then
+     NewSelectedItem := FStoredItems[vIndexValue];
+ end;
+
+
  if (NewSelectedItem <> FStoredSelectedItem) or (AForceUpdate) then
  begin
   FStoredSelectedItem:= NewSelectedItem;

--- a/Beta/D2Bridge Framework/Prism/Prism.Forms.pas
+++ b/Beta/D2Bridge Framework/Prism/Prism.Forms.pas
@@ -781,8 +781,6 @@ begin
   end;
  end;
 
- UpdateControls;
-
 end;
 procedure TPrismForm.OnBeforePageLoad;
 begin

--- a/Beta/D2Bridge Framework/Prism/Prism.Interfaces.pas
+++ b/Beta/D2Bridge Framework/Prism/Prism.Interfaces.pas
@@ -1142,6 +1142,8 @@ type
    function GetCaption: string;
    procedure SetCaption(const Value: string);
    function GetItems: TStrings;
+   function GetValues: TStrings;
+
    function GetColumns: Integer;
    procedure SetColumns(const Value: Integer);
 
@@ -1149,6 +1151,8 @@ type
 
    property Caption: string read GetCaption write SetCaption;
    property Items: TStrings read GetItems;
+   property Values: TStrings read GetValues;
+
    property Columns: integer read GetColumns write SetColumns;
  end;
 {$ENDIF}

--- a/Beta/D2Bridge Framework/Prism/Prism.Server.HTML.Headers.pas
+++ b/Beta/D2Bridge Framework/Prism/Prism.Server.HTML.Headers.pas
@@ -134,7 +134,10 @@ begin
     if (APrismForm.Controls[I].Events.Item(Z).AutoPublishedEvent) or
        (APrismForm.Controls[I].Events.Item(Z).EventType in [EventOnKeyDown, EventOnKeyUp, EventOnKeyPress]) then
     begin
-     add('_EV'+AnsiUpperCase(APrismForm.Controls[I].NamePrefix) + '.addEventListener("' + EventJSName(APrismForm.Controls[I].Events.Item(Z).EventType) + '", function(event) {');
+     if APrismForm.Controls[I].Events.Item(Z).EventType = EventOnChange then
+      add('$(_EV'+AnsiUpperCase(APrismForm.Controls[I].NamePrefix)+').on("'+EventJSName(APrismForm.Controls[I].Events.Item(Z).EventType)+'", function(event) {')
+     else
+      add('_EV'+AnsiUpperCase(APrismForm.Controls[I].NamePrefix) + '.addEventListener("' + EventJSName(APrismForm.Controls[I].Events.Item(Z).EventType) + '", function(event) {');
 
      //checkRequired
      if (APrismForm.Controls[I].NeedCheckValidation) then
@@ -483,7 +486,7 @@ begin
   if Assigned((vSession.ActiveForm as TPrismForm).OnProcessHTML) then
   (vSession.ActiveForm as TPrismForm).OnProcessHTML((vSession.ActiveForm as TPrismForm), HTMLText);
 
-  //Chama o Inicio da Tradução
+  //Chama o Inicio da Traduï¿½ï¿½o
   (vSession.ActiveForm as TPrismForm).DoBeginTranslate;
 
   //Part I
@@ -492,8 +495,8 @@ begin
 
   //Processa $prismbody
   HTMLBodyText:= TD2BridgeClass(vSession.D2BridgeBaseClassActive).HTML.Render.Body.Text;
-  //Retirado a Parte I porque quando usa template mas não tem os elementos declarados
-  //ao entrar uma segunda vez os elementos não atualizam
+  //Retirado a Parte I porque quando usa template mas nï¿½o tem os elementos declarados
+  //ao entrar uma segunda vez os elementos nï¿½o atualizam
   //Part I - Processa o Body
   //Session.ActiveForm.ProcessControlsToHTML(HTMLBodyText);
   HTMLText:= StringReplace(HTMLText, '$prismbody', HTMLBodyText, [rfIgnoreCase]);
@@ -528,7 +531,7 @@ begin
   //Processa as CallBack TAGs HTML {{Texto}}
   vSession.ActiveForm.ProcessCallBackTagHTML(HTMLText);
 
-  //FIX - Corrige a renderização do GridDataModel
+  //FIX - Corrige a renderizaï¿½ï¿½o do GridDataModel
   //Session.ActiveForm.ProcessControlsToHTML(HTMLText);
 
   //Translate
@@ -578,7 +581,7 @@ end;
 
 Procedure TPrismServerHTMLHeaders.LoadPageHTMLFromSession(const Request: TPrismHTTPRequest; Response: TPrismHTTPResponse; Session: TPrismSession);
 begin
- //Obrigatório rodar dentro da Thread
+ //Obrigatï¿½rio rodar dentro da Thread
  Session.ExecThread(True,
   Exec_LoadPageHTMLFromSession,
   TValue.From<TPrismHTTPRequest>(Request),

--- a/README
+++ b/README
@@ -15,7 +15,7 @@ São Paulo - Brazil
 
 ## Version
 Beta (LGPL 2.1 License)
-- D2Bridge Framework 2.5.81
+- D2Bridge Framework 2.5.82
 
 Stable
 - D2Bridge Framework 2.0.8


### PR DESCRIPTION
## 🔧 Descrição

Este PR adiciona ajustes complementares ao PR #25.

### ✅ Alterações realizadas
- Ajuste no tratamento do evento `OnChange` em `Prism.Server.HTML.Headers.pas`
  - Uso de `jQuery.on()` ao invés de `addEventListener` para este evento específico
- Remoção da chamada `UpdateControls` em `Prism.Forms.pas`

### 🎯 Objetivo
- Corrigir o comportamento do evento `OnChange`
- Evitar possíveis efeitos colaterais relacionados à chamada de `UpdateControls`

### 📌 Observações
- Alterações isoladas apenas nos arquivos necessários
- Não foram incluídas modificações em arquivos de demo
- Mantida compatibilidade com os demais eventos existentes