### PR TITLE
Fix EventD2Bridge Types and Events handling

### DIFF
--- a/Beta/D2Bridge Framework/D2Bridge.Manager.pas
+++ b/Beta/D2Bridge Framework/D2Bridge.Manager.pas
@@ -366,7 +366,7 @@ end;
 
 class function TD2BridgeManager.Version: string;
 begin
- Result:= '2.5.81'; //Version of D2Bridge Framework
+ Result:= '2.5.82'; //Version of D2Bridge Framework
 end;
 
 end.

--- a/Beta/D2Bridge Framework/Prism/Prism.Events.pas
+++ b/Beta/D2Bridge Framework/Prism/Prism.Events.pas
@@ -254,17 +254,19 @@ begin
     FCriticalSession.Leave;
    end;
   end;
-
-  if self <> nil then
-   if Assigned(FPrismControl) and
-      Assigned(FPrismControl.Form) and
-      Assigned(FPrismControl.Session) and
-      (not FPrismControl.Session.Closing) and
-      (not (csDestroying in (FPrismControl.Session as TPrismSession).ComponentState)) then
-    begin
-     (FPrismControl.Form as TPrismForm).DoEventD2Bridge(FPrismControl as TPrismControl, EventType, Parameters);
-    end;
+  // Movido o Trecho completo do DoEventD2Bridge para fora do Else, assim sempre será executando.
+  // Alisson - 04/06/2026
  end;
+
+ if self <> nil then
+  if Assigned(FPrismControl) and
+     Assigned(FPrismControl.Form) and
+     Assigned(FPrismControl.Session) and
+     (not FPrismControl.Session.Closing) and
+     (not (csDestroying in (FPrismControl.Session as TPrismSession).ComponentState)) then
+   begin
+    (FPrismControl.Form as TPrismForm).DoEventD2Bridge(FPrismControl as TPrismControl, EventType, Parameters);
+   end;
 end;
 
 function TPrismControlEvent.CallEventResponse(Parameters: TStrings): string;
@@ -287,7 +289,8 @@ begin
  FEventType := AEventType;
  FPrismControl := AOwner;
 
- if AEventType in [EventOnClick, EventOnDblClick, EventOnChange, EventOnPrismControlEvent] then
+ if AEventType in [EventOnClick, EventOnDblClick, EventOnChange, EventOnPrismControlEvent,
+                   EventOnExit, EventOnCheckChange, EventOnCheck, EventOnSelect] then
   FAutoPublishedEvent:= true
  else
   FAutoPublishedEvent:= false;

--- a/Beta/D2Bridge Framework/Prism/Prism.Types.pas
+++ b/Beta/D2Bridge Framework/Prism/Prism.Types.pas
@@ -300,6 +300,9 @@ begin
  else
  if PrismEventType = EventOnSelect then
   result:= 'input'
+ else
+ if PrismEventType = EventOnExit then
+  result:= 'blur'
 end;
 
 

--- a/README
+++ b/README
@@ -15,7 +15,7 @@ São Paulo - Brazil
 
 ## Version
 Beta (LGPL 2.1 License)
-- D2Bridge Framework 2.5.81
+- D2Bridge Framework 2.5.82
 
 Stable
 - D2Bridge Framework 2.0.8


### PR DESCRIPTION
fix: EventD2Bridge not firing for OnExit, OnCheck, OnCheckChange and OnSelect events

Three fixes applied to ensure EventD2Bridge dispatches correctly across all control types:

1. Prism.Events.pas — CallEvent: DoEventD2Bridge block moved outside the else branch
   Previously, DoEventD2Bridge was only called when FNotifyEvent was nil (else path).
   Any code using the SetOnEvent(TNotifyEvent) overload would silently skip EventD2Bridge.
   Moving the block outside the if/else ensures it always executes regardless of the path taken.

2. Prism.Events.pas — Constructor: AutoPublishedEvent extended to additional event types
   EventOnExit, EventOnCheckChange, EventOnCheck and EventOnSelect were not included in the
   AutoPublishedEvent = true set. As a result, AddControlEvents never generated the
   corresponding addEventListener calls in the browser-side JS, so these events never reached
   the server even when a VCL handler was assigned on the form.
   Fix: included EventOnExit, EventOnCheckChange, EventOnCheck and EventOnSelect in the set.

3. Prism.Types.pas — EventJSName: added mapping for EventOnExit
   Without this mapping, the addEventListener generated for EventOnExit had an empty event
   name, making it invalid. EventOnExit now correctly maps to the browser 'blur' event.

Impact: OnExit on any control, OnCheck/OnCheckChange on CheckBox and RadioGroup, and
OnSelect on Combobox now correctly reach the server and trigger EventD2Bridge when a
VCL handler is assigned on the form. No behavioral change for previously working events.