### PR TITLE
fix: preserve HTML template on force update in Button and Edit

### DIFF
--- a/Beta/D2Bridge Framework/D2Bridge.Manager.pas
+++ b/Beta/D2Bridge Framework/D2Bridge.Manager.pas
@@ -327,7 +327,7 @@ begin
   InterfaceGUID := GetTypeData(InterfaceTypeInfo).Guid;
 
   try
-   // Itere sobre todas as classes carregadas no tempo de execução
+   // Itere sobre todas as classes carregadas no tempo de execuï¿½ï¿½o
    for Classe in GetRegisteredClass do
    begin
      if Supports(Classe, InterfaceGUID) then
@@ -366,7 +366,7 @@ end;
 
 class function TD2BridgeManager.Version: string;
 begin
- Result:= '2.5.82'; //Version of D2Bridge Framework
+ Result:= '2.5.83'; //Version of D2Bridge Framework
 end;
 
 end.

--- a/Beta/D2Bridge Framework/Prism/Prism.Button.pas
+++ b/Beta/D2Bridge Framework/Prism/Prism.Button.pas
@@ -225,27 +225,31 @@ begin
  inherited;
 
  NewCaption:= Caption;
- if (AForceUpdate) or (FStoredCaption <> NewCaption) then
+ if FStoredCaption <> NewCaption then
  begin
   FStoredCaption := NewCaption;
-  //ScriptJS.Add('document.querySelector("[id='+AnsiUpperCase(NamePrefix)+' i]").innerHTML = '+ FormatValueHTML(FStoredCaption) +';');
 
-  ScriptJS.Add(
-  '(() => {'+
-  '  const el = document.querySelector("[id='+AnsiUpperCase(NamePrefix)+' i]");'+
-  '  if (!el) return;'+
-  '  const badge = el.querySelector("span.d2bridgelabelbadge");'+
-  '  if (badge) {'+
-  '    const badgeHTML = badge.outerHTML;'+
-  '    const wasBefore = (badge.previousSibling === null);'+
-  '    el.innerHTML = '+FormatValueHTML(FStoredCaption)+';'+
-  '    if (wasBefore) el.insertAdjacentHTML("afterbegin", badgeHTML);'+
-  '    else el.insertAdjacentHTML("beforeend", badgeHTML);'+
-  '  } else {'+
-  '    el.innerHTML = '+FormatValueHTML(FStoredCaption)+';'+
-  '  }'+
-  '})();'
-  );
+  if not AForceUpdate then
+  begin
+   //ScriptJS.Add('document.querySelector("[id='+AnsiUpperCase(NamePrefix)+' i]").innerHTML = '+ FormatValueHTML(FStoredCaption) +';');
+
+   ScriptJS.Add(
+   '(() => {'+
+   '  const el = document.querySelector("[id='+AnsiUpperCase(NamePrefix)+' i]");'+
+   '  if (!el) return;'+
+   '  const badge = el.querySelector("span.d2bridgelabelbadge");'+
+   '  if (badge) {'+
+   '    const badgeHTML = badge.outerHTML;'+
+   '    const wasBefore = (badge.previousSibling === null);'+
+   '    el.innerHTML = '+FormatValueHTML(FStoredCaption)+';'+
+   '    if (wasBefore) el.insertAdjacentHTML("afterbegin", badgeHTML);'+
+   '    else el.insertAdjacentHTML("beforeend", badgeHTML);'+
+   '  } else {'+
+   '    el.innerHTML = '+FormatValueHTML(FStoredCaption)+';'+
+   '  }'+
+   '})();'
+   );
+  end;
 
  end;
 

--- a/Beta/D2Bridge Framework/Prism/Prism.Edit.pas
+++ b/Beta/D2Bridge Framework/Prism/Prism.Edit.pas
@@ -344,11 +344,9 @@ begin
  end;
 
  NewDataType:= DataType;
- if (AForceUpdate) or (FStoredDataType <> NewDataType) then
- begin
-  FStoredDataType:= NewDataType;
-  ScriptJS.Add('document.querySelector("[id='+AnsiUpperCase(NamePrefix)+' i]").' + InputHTMLTypeByPrismFieldType(FStoredDataType) +';');
- end;
+ if FStoredDataType <> NewDataType then
+  ScriptJS.Add('document.querySelector("[id='+AnsiUpperCase(NamePrefix)+' i]").' + InputHTMLTypeByPrismFieldType(NewDataType) +';');
+ FStoredDataType:= NewDataType;
 
  NewTextMask:= TextMask;
  if (AForceUpdate) or (FStoredTextMask <> NewTextMask) then

--- a/Beta/DOC/D2Bridge_EN.md
+++ b/Beta/DOC/D2Bridge_EN.md
@@ -51,7 +51,7 @@ D2Bridge is an open-source framework that enables converting Delphi or Lazarus a
 |-----------|-------|
 | **Author** | Talis Jonatas Gomes |
 | **License** | LGPL 2.1 |
-| **Beta Version** | 2.5.76+ |
+| **Beta Version** | 2.5.83 |
 | **Stable Version** | 2.0.8 |
 | **Delphi** | 10.0 - 13.0 |
 | **Lazarus** | 3.4 - 4.4 (Windows) |

--- a/Beta/DOC/D2Bridge_PL.md
+++ b/Beta/DOC/D2Bridge_PL.md
@@ -51,7 +51,7 @@ D2Bridge to framework open-source umożliwiający konwersję aplikacji napisanyc
 |----------|---------|
 | **Autor** | Talis Jonatas Gomes |
 | **Licencja** | LGPL 2.1 |
-| **Wersja Beta** | 2.5.76+ |
+| **Wersja Beta** | 2.5.83 |
 | **Wersja Stable** | 2.0.8 |
 | **Delphi** | 10.0 - 13.0 |
 | **Lazarus** | 3.4 - 4.4 (Windows) |


### PR DESCRIPTION
- Prism.Button.pas: JS de innerHTML so emitido quando caption realmente muda em runtime (not AForceUpdate). No force update, FStoredCaption e atualizado silenciosamente sem sobrescrever spans do template.

- Prism.Edit.pas: JS de type so emitido quando DataType muda em runtime. Remove AForceUpdate da condicao para preservar atributos como type=password definidos no template HTML.