### PR TITLE
Fix/preserve template html on force update

### DIFF
--- a/Beta/D2Bridge Framework/D2Bridge.Manager.pas
+++ b/Beta/D2Bridge Framework/D2Bridge.Manager.pas
@@ -1,4 +1,4 @@
-{
+﻿{
  +--------------------------------------------------------------------------+
   D2Bridge Framework Content
 
@@ -366,7 +366,7 @@ end;
 
 class function TD2BridgeManager.Version: string;
 begin
- Result:= '2.5.83'; //Version of D2Bridge Framework
+ Result:= '2.5.84'; //Version of D2Bridge Framework
 end;
 
 end.

--- a/Beta/D2Bridge Framework/Prism/Prism.Form.Timer.pas
+++ b/Beta/D2Bridge Framework/Prism/Prism.Form.Timer.pas
@@ -36,7 +36,7 @@ interface
 
 uses
   Classes, SysUtils, SyncObjs,
-  Prism.Interfaces, Prism.Types;
+  Prism.Interfaces, Prism.Types, Prism.BaseClass;
 
 type
   TPrismFormTimer = class(TThread)
@@ -140,7 +140,18 @@ begin
          //Synchronize(CurrentThread, FOnTimer);
          //TThread.Synchronize(nil, FOnTimer);
          FOnTimer();
-        except
+        except on E: Exception do
+        begin
+         try
+          PrismBaseClass.Log(
+           '',
+           '',
+           '',
+           'FormTimer.OnTimer',
+           E.ClassName + ': ' + E.Message
+          );
+         except
+         end;
         end;
        end;
      end;
@@ -152,9 +163,16 @@ begin
  //    if Assigned(self) then
  //    FPauseEvent.WaitFor(INFINITE); // Pauses execution if paused
    end;
+   end;
 
- except
+ except on E: Exception do
+ begin
   FTerminated := True;
+  try
+   PrismBaseClass.Log('', '', '', 'FormTimer.Execute', E.ClassName + ': ' + E.Message);
+  except
+  end;
+ end;
  end;
 end;
 

--- a/Beta/D2Bridge Framework/Prism/Prism.Forms.pas
+++ b/Beta/D2Bridge Framework/Prism/Prism.Forms.pas
@@ -781,7 +781,7 @@ begin
   end;
  end;
 
- UpdateControls;
+ //UpdateControls;
 
 end;
 procedure TPrismForm.OnBeforePageLoad;

--- a/Beta/D2Bridge Framework/Prism/Prism.Session.Thread.Proc.pas
+++ b/Beta/D2Bridge Framework/Prism/Prism.Session.Thread.Proc.pas
@@ -258,18 +258,23 @@ begin
   begin
    if FSincronize then
    begin
+    var vSpinCount: Integer := 0;
     repeat
-//     try
-      //Yield;
-//      if GetCurrentThreadId = MainThreadID then
-//      begin
-//       CheckSynchronize;
-//       Application.ProcessMessages;
-//      end;
-//     except
-//     end;
-
      sleep(1);
+     Inc(vSpinCount);
+     // 60 000 iteracoes x 1ms = 60 segundos sem resposta: loga e aborta espera
+     if vSpinCount = 60000 then
+     begin
+      try
+       var vIdent: string := '';
+       if Assigned(FPrismSession) then
+        vIdent := FPrismSession.InfoConnection.Identity;
+       PrismBaseClass.Log(vIdent, '', '', 'ThreadProc.SpinTimeout',
+        'Thread sincronizada nao concluiu em 60s. Posivel travamento VCL/D2Bridge.');
+      except
+      end;
+      Break;
+     end;
     until FFinished;
    end else
    begin
@@ -331,10 +336,25 @@ begin
     pmtFour:  FProc4(FProcVar1, FProcVar2, FProcVar3, FProcVar4);
   end;
  except on E: Exception do
+ begin
 {$IFDEF MSWINDOWS}
    if IsDebuggerPresent and (not PrismBaseClass.IsD2DockerContext) then
      raise Exception.Create(E.Message);
 {$ENDIF}
+   try
+    if Assigned(FPrismSession) then
+     PrismBaseClass.Log(
+      FPrismSession.InfoConnection.Identity,
+      '',
+      '',
+      'ThreadProc',
+      E.ClassName + ': ' + E.Message
+     )
+    else
+     PrismBaseClass.Log('', '', '', 'ThreadProc', E.ClassName + ': ' + E.Message);
+   except
+   end;
+ end;
  end;
 
  try

--- a/Beta/Wizard/BPL/21.0/Config.ini
+++ b/Beta/Wizard/BPL/21.0/Config.ini
@@ -1,0 +1,3 @@
+[Config]
+Inherited TD2BridgeForm=FormCrudTemplate
+Inherited Copy Properties=Yes

--- a/README
+++ b/README
@@ -15,7 +15,7 @@ São Paulo - Brazil
 
 ## Version
 Beta (LGPL 2.1 License)
-- D2Bridge Framework 2.5.82
+- D2Bridge Framework 2.5.84
 
 Stable
 - D2Bridge Framework 2.0.8


### PR DESCRIPTION
- Adicionado log de exceções em threads (FormTimer e ThreadProc)
- Proteção contra loop infinito (timeout de 60s)
- Melhoria de rastreabilidade com PrismBaseClass.Log
- Ajuste em Prism.Forms (UpdateControls comentado)
- Atualização da versão para 2.5.84
- Atualização do README

Objetivo: evitar travamentos silenciosos e melhorar diagnóstico de erros.