### PR TITLE
docs: convert Resource Monitor guide to Markdown + add NSSM service guide

### DIFF
--- a/Beta/DOC/D2Bridge_Resource_Monitor.md
+++ b/Beta/DOC/D2Bridge_Resource_Monitor.md
@@ -9,9 +9,9 @@ Usage Guide
 * [⚙️Configuration Parameters](#Configuration-Parameters)
 * [📂Where the Log Is Written](#Where-the-Log-Is-Written)
     * [Example Log Entry](#Example-Log-Entry)
-* [📝Configuration - Option 1: Using an INI File (Recommended)](#Configuration-Option-1:-Using-an-INI-File-(Recommended))
+* [📝Configuration - Option 1: Using an INI File (Recommended)](#-Configuration---Option-1-Using-an-INI-File-(Recommended))
     * [Ini File Example](#Ini-File-Example)
-* [💻Configuration - Option 2: Programmatic Configuration (Properties)](#Configuration-Option-2:-Programmatic-Configuration-(Properties))
+* [💻Configuration - Option 2: Programmatic Configuration (Properties)](#Configuration---Option-2-Programmatic-Configuration-(Properties))
 * [⚠️Important Notes](#Important-Notes)
 ---
 

--- a/Beta/DOC/D2Bridge_Resource_Monitor.md
+++ b/Beta/DOC/D2Bridge_Resource_Monitor.md
@@ -1,0 +1,162 @@
+# 📊D2Bridge Resource Monitor
+
+Usage Guide
+
+## 📑 Table of Contents
+
+* [❓What Is the Resource Monitor](#What-Is-the-Resource-Monitor)
+* [🔍What Is Collected in Each Snapshot](#What-Is-Collected-in-Each-Snapshot)
+* [⚙️Configuration Parameters](#Configuration-Parameters)
+* [📂Where the Log Is Written](#Where-the-Log-Is-Written)
+    * [Example Log Entry](#Example-Log-Entry)
+* [📝Configuration - Option 1: Using an INI File (Recommended)](#Configuration-Option-1:-Using-an-INI-File-(Recommended))
+    * [Ini File Example](#Ini-File-Example)
+* [💻Configuration - Option 2: Programmatic Configuration (Properties)](#Configuration-Option-2:-Programmatic-Configuration-(Properties))
+* [⚠️Important Notes](#Important-Notes)
+---
+
+### ❓What Is the Resource Monitor
+
+The Resource Monitor is a diagnostic telemetry module of D2Bridge that periodically captures the resource state of a Windows server and records this information in the application log file.
+
+* It operates independently from functional logs such as exceptions, access, and security logs.
+
+* Its primary purpose is to help identify CPU and memory bottlenecks in production environments.
+
+### 🔍What Is Collected in Each Snapshot
+
+Each snapshot records the following information:
+
+* **Level:** Indicates Info or Warning. A Warning level is triggered when CPU or memory usage exceeds the configured thresholds.
+
+* **MachineName:** Windows server name.
+
+* **App / PID:** Application executable name and current process ID.
+
+* **AppCPU:** Percentage of CPU consumed by the application process since the last interval.
+
+* **AppWorkingSetMB:** Physical memory allocated to the process (Working Set).
+
+* **AppCommitMB:** Virtual memory committed by the process.
+
+* **SystemMemoryLoad:** Percentage of total physical memory usage by Windows.
+
+* **SystemAvailable MemoryMB:** Available physical memory in the system.
+
+* **System TotalPhysicalMemoryMB:** Total installed RAM.
+
+* **Sessions:** Number of active sessions on the D2Bridge server.
+
+* **TopCPU:** The top N processes with the highest CPU usage at the time of the snapshot.
+
+* **TopMemory:** The top N processes with the highest Working Set at the time of the snapshot.
+
+> **Note:** During the first collection after server startup, `AppCPU` and `TopCPU` appear as _collecting_, because no previous interval exists for comparison.
+
+### ⚙️Configuration Parameters
+
+The following parameters control the behavior of the Resource Monitor:
+
+* **Resource Monitor**
+
+  * **Type:** Boolean
+  * **Default:** False
+  * _Description:_ Enables or disables the resource monitor.
+
+* **Resource MonitorIntervalSec**
+
+  * **Type:** Integer
+  * **Default:** 300
+  * _Description:_ Interval between snapshots, in seconds (minimum value: 15).
+
+* **Resource Monitor Top ProcessCount**
+
+  * **Type:** Integer
+  * **Default:** 3
+  * _Description:_ Number of processes listed in Top CPU and Top Memory.
+
+* **Resource MonitorCPUAlertPercent**
+
+  * **Type:** Integer
+  * **Default:** 70
+  * _Description:_ Application CPU usage percentage that elevates the log level to Warning.
+
+* **Resource Monitor MemoryAlertMB**
+
+  * **Type:** UInt64
+  * **Default:** 2048
+  * _Description:_ Application Working Set (in MB) that elevates the log level to Warning.
+
+* **To disable CPU alerts**, set `Resource Monitor CPUAlertPercent` to 0.
+
+* **To disable memory alerts**, set `Resource Monitor MemoryAlertMB` to 0.
+
+### 📂Where the Log Is Written
+
+Each snapshot is written using the `LogDiagnostic` method to the same log file used by the application, located in:
+
+Plaintext
+
+```
+wwwroot\log\
+```
+
+The log file behavior follows the `LogFileMode` setting:
+
+* **session:** One log file per server execution (default).
+
+* **daily:** One log file per day, using the format `YYYY_MM_DD.txt`.
+
+The log object is created automatically when the server starts with `Resource Monitor = True`, even if other logs (exception, access, security) are disabled.
+
+#### Example Log Entry
+
+Each snapshot is recorded as a single diagnostic log entry containing all collected fields.
+
+> (The exact format depends on the configured log layout.)
+
+### 📝Configuration - Option 1: Using an INI File (Recommended)
+
+This is the recommended approach for production environments, as it allows configuration changes without recompiling the application.
+
+The project INI file must contain a `[D2Bridge Log]` section with the parameters listed above. If a parameter does not exist, D2Bridge automatically creates it with the default value during the first execution.
+
+To enable INI-based configuration, the `UseINIConfig` option must be enabled. 
+
+Verify that the property is enabled in the `ServerController` component, or enable it by code before calling `StartServer`.
+
+#### Ini File Example:
+
+Ini, TOML
+```ini
+[D2Bridge Log]
+LogFileMode=daily
+Resource Monitor=True
+Resource MonitorIntervalSec=20
+Resource Monitor Top ProcessCount=3
+Resource Monitor CPUAlertPercent=70
+Resource Monitor MemoryAlertMB=2048
+```
+### 💻Configuration - Option 2: Programmatic Configuration (Properties)
+
+This approach is useful when you do not want to rely on an INI file, or when configuration must be performed dynamically at runtime before `StartServer`.
+
+Internally, the `TPrism Resource Monitor.Configure` method is invoked. When configuring by code, the correct approach is:
+
+1. Disable `UseINIConfig`.
+
+2. Call the configuration method during the `OnBeforeServerStart` event (or in the `WebApp FormCreate`, before calling `StartServer`).
+
+> **Important:** Verify the exact method name exposed by your `ServerController`. In some projects it may be accessible via `Prism.Resource Monitor.Configure(...)` or through a wrapper in `ServerControllerBase`.
+> 
+> Use IntelliSense with `ServerController.Prism.` to locate the correct member.
+
+### ⚠️Important Notes
+
+> * The Resource Monitor **operates only on Windows**, as it relies on Windows APIs such as `psapi.dll`, `kernel32.dll`, and `GetSystemTimes`. On Linux or Lazarus targets, the module is compiled but does not collect data.
+>
+> * The Resource Monitor timer is **independent from the session timer**. Enabling or disabling the monitor does not affect session heartbeats.
+>
+> * An **initial snapshot is generated immediately** after the server finishes startup (`StartServer`), before the first timer interval, providing an immediate baseline in the log.
+>
+> * The `ResourceMonitor` field in the `[D2Bridge Log]` section of the INI file must be set to `True`. The INI reader uses `ReadBool`, so the value is **case-insensitive**.

--- a/Beta/DOC/D2Bridge_Resource_Monitor.md
+++ b/Beta/DOC/D2Bridge_Resource_Monitor.md
@@ -9,10 +9,10 @@ Usage Guide
 * [⚙️Configuration Parameters](#Configuration-Parameters)
 * [📂Where the Log Is Written](#Where-the-Log-Is-Written)
     * [Example Log Entry](#Example-Log-Entry)
-* [📝Configuration - Option 1: Using an INI File (Recommended)](#-Configuration---Option-1-Using-an-INI-File-(Recommended))
+* [📝Configuration - Option 1: Using an INI File (Recommended)](#configuration---option-1-using-an-ini-file-recommended)
     * [Ini File Example](#Ini-File-Example)
-* [💻Configuration - Option 2: Programmatic Configuration (Properties)](#Configuration---Option-2-Programmatic-Configuration-(Properties))
-* [⚠️Important Notes](#Important-Notes)
+* [💻Configuration - Option 2: Programmatic Configuration (Properties)](#configuration---option-2-programmatic-configuration-properties)
+* [⚠️Important Notes](#%EF%B8%8Fimportant-notes)
 ---
 
 ### ❓What Is the Resource Monitor

--- a/Beta/DOC/D2Bridge_Windows_Service.md
+++ b/Beta/DOC/D2Bridge_Windows_Service.md
@@ -1,0 +1,205 @@
+# ⚙️ D2Bridge Framework
+
+## How to Run the EXE as a Windows Service
+
+> **Author of findings:** Core analysis of the D2Bridge Framework (Beta)
+>
+> **Date:** April 2026
+
+---
+
+# 📑 Índice
+
+1. [📋Overview](overview)
+
+2. [🔍How the Framework Detects Service Mode](how-the-framework-detects-service-mode)
+
+3. [🔄Changes in Server Behavior](changes-in-server-behavior)
+
+4. [📂Configuring Server Port and Name Without a Console](configuring-server-port-and-name-without-a-console)
+
+5. [💻Registering the Application as a Windows Service](registering-the-application-as-a-windows-service)
+
+6. [🚀Full Service Initialization Flow](full-service-initialization-flow)
+
+7. [⚠️Important Notes](important-notes)
+
+1. ### 📋Overview
+
+* The D2Bridge Framework core already includes native support for detection and execution as a Windows Service.
+
+* No changes to the project source code or the `.dpr` file are required.
+
+* The framework automatically detects when it is running as a Windows service and adapts its behavior accordingly.
+
+---
+
+2. ### 🔍How the Framework Detects Service Mode
+
+In the file `D2Bridge.Util.pas`, the function `IsRunningAsService` determines whether the application is running as a Windows service by combining two conditions:
+
+1. The process is running in **Windows Session 0**, which is reserved exclusively for system services.
+2. There is **no interactive desktop** available, meaning the call to `OpenInputDesktop` returns an invalid handle.
+
+If both conditions are true, the function returns `TRUE`, indicating that the process is executing as a Windows service.
+
+#### Code excerpt (`D2Bridge.Util.pas`):
+```pascal
+function IsRunningAsService: Boolean;
+var
+  SessionId: DWORD;
+  hDesk: THandle;
+begin
+  Result := False;
+  if not ProcessIdToSessionId(GetCurrentProcessId, SessionId) then
+    Exit(False);
+    
+  if SessionId <> 0 then
+    Exit(False);
+    
+  hDesk := OpenInputDesktop(0, False, DESKTOP_SWITCHDESKTOP);
+  if hDesk <> 0 then
+  begin
+    CloseDesktop(hDesk);
+    Exit(False);
+  end;
+  
+  Result := True; // Session 0 + no interactive desktop = service
+end;
+```
+---
+
+3. ### 🔄Changes in Server Behavior
+
+In `D2Bridge.ServerControllerBase.pas`, the method `CheckNeedConsole` uses the result returned by `IsRunningAsService`.
+```pascal
+function TD2BridgeServerControllerBase.CheckNeedConsole: boolean;
+begin
+  result := true;
+  {$IFDEF MSWINDOWS}
+  result := not IsRunningAsService;
+  {$ENDIF}
+  result := not IsD2DockerContext;
+end;
+```
+When `IsRunningAsService` returns `TRUE`, the `NeedConsole` flag becomes `FALSE`. As a result, all console-related interaction is automatically skipped.
+
+Specifically:
+
+* The interactive prompt for server port and server name is **not displayed**.
+
+* The status screen with counters and resource monitoring is **not displayed**.
+
+* The server **starts immediately** without any user interaction.
+
+* The internal main loop continues to run normally, but without console output, performing **internal monitoring only**.
+
+---
+
+4. ### 📂Configuring Server Port and Name Without a Console
+
+When running without a console, the server reads configuration values directly from a file named `Config.ini`, located in the same directory as the executable file.
+
+#### Code excerpt (`D2Bridge.APPConfig.pas`):
+```pascal
+function TD2BridgeAPPConfig.ServerPort(ADefaultPort: Integer): Integer;
+begin
+  Result := FFileINIConfig.ReadInteger('D2Bridge Server Config', 'Server Port', ADefaultPort);
+end;
+
+function TD2BridgeAPPConfig.ServerName(...): String;
+begin
+  Result := FFileINIConfig.ReadString('D2Bridge Server Config', 'Server Name', ADefaultServerName);
+end;
+```
+#### Required configuration file
+
+Before registering the application as a service, create a file named `Config.ini` in the same directory as the executable with the following content:
+```ini
+[D2Bridge Server Config]
+Server Port=8888
+Server Name=YourServerName
+```
+> 💡 Replace `8888` with your desired port number and `YourServerName` with your preferred server name.
+---
+5. ### 💻Registering the Application as a Windows Service
+
+> 🚨 **Prerequisite:** Run Command Prompt (`cmd`) or PowerShell as **Administrator**.
+
+#### Option A: Using `SC.EXE` (Native Windows Tool)
+
+* **Register the service:**
+  ```bash
+  sc create ServiceName binPath= "C:\Full\Path\Application.exe" start= auto DisplayName= "Visible Service Name"
+  ```
+* **Start the service:**
+  ```bash
+  sc start ServiceName
+  ```
+* **Stop the service:**
+  ```bash
+  sc stop ServiceName
+  ```
+* **Remove the service:**
+  ```bash
+  sc delete ServiceName
+  ```
+> ⚠️ **Important:** The space after `binPath=` and `start=` is strictly mandatory when using `sc.exe`.
+
+#### Option B: Using NSSM (Recommended for Production)
+
+NSSM (Non-Sucking Service Manager) is a free tool that provides automatic restart on crashes and supports redirection of output to log files.
+
+* **Download:** <https://nssm.cc/download>
+
+* **Install using the graphical interface:**
+  ```bash
+  nssm install ServiceName
+  ```
+* **Install via command line:**
+  ```bash
+  nssm install ServiceName "C:\Full\Path\Application.exe"
+  ```
+* **Start the service:**
+  ```bash
+  nssm start ServiceName
+  ```
+* **Stop and remove the service:**
+  ```bash
+  nssm stop ServiceName
+  nssm remove ServiceName confirm
+  ```
+---
+6. ### 🚀Full Service Initialization Flow
+
+1. Windows starts the service in Session 0 without an interactive desktop.
+
+2. The executable process is launched.
+
+3. `IsRunningAsService` returns `TRUE`.
+
+4. `NeedConsole` is set to `FALSE`.
+
+5. `TD2BridgeServerConsole.Run` is executed (same logic as console mode).
+
+6. The console configuration screen is skipped.
+
+7. Server port and server name are read from `Config.ini`.
+
+8. `D2BridgeServerController.StartServer` is executed normally.
+
+9. The HTTP/HTTPS server starts accepting connections.
+
+10. The internal loop keeps the process alive while the server is running.
+---
+7. ### ⚠️Important Notes
+
+* The `.dpr` file **does not require any modification**.
+
+* The `Config.ini` file **must exist** before starting the service for the first time. If it does not exist, default values defined in the code will be used (port 8888 and the default server name).
+
+* **SSL certificate paths** must be configured in the code before compilation, as there is no interactive way to configure them when running as a service.
+
+* Errors and crashes can be inspected using **Windows Event Viewer**: `eventvwr.msc` $\rightarrow$ _Windows Logs_ $\rightarrow$ _Application_.
+
+* The service runs under the **SYSTEM account** by default. If access to network resources is required (remote databases, shared folders, etc.), configure a dedicated service account with appropriate permissions.

--- a/Beta/DOC/D2Bridge_Windows_Service.md
+++ b/Beta/DOC/D2Bridge_Windows_Service.md
@@ -10,21 +10,23 @@
 
 # 📑 Índice
 
-1. [📋Overview](overview)
+1. [📋Overview](#1-overview)
 
-2. [🔍How the Framework Detects Service Mode](how-the-framework-detects-service-mode)
+2. [🔍How the Framework Detects Service Mode](#2-how-the-framework-detects-service-mode)
 
-3. [🔄Changes in Server Behavior](changes-in-server-behavior)
+3. [🔄Changes in Server Behavior](#3-changes-in-server-behavior)
 
-4. [📂Configuring Server Port and Name Without a Console](configuring-server-port-and-name-without-a-console)
+4. [📂Configuring Server Port and Name Without a Console](#4-configuring-server-port-and-name-without-a-console)
 
-5. [💻Registering the Application as a Windows Service](registering-the-application-as-a-windows-service)
+5. [💻Registering the Application as a Windows Service](#5-registering-the-application-as-a-windows-service)
 
-6. [🚀Full Service Initialization Flow](full-service-initialization-flow)
+6. [🚀Full Service Initialization Flow](#6-full-service-initialization-flow)
 
-7. [⚠️Important Notes](important-notes)
+7. [⚠️Important Notes](#7-%EF%B8%8Fimportant-notes)
 
-1. ### 📋Overview
+---
+
+### 1. 📋Overview
 
 * The D2Bridge Framework core already includes native support for detection and execution as a Windows Service.
 
@@ -34,7 +36,7 @@
 
 ---
 
-2. ### 🔍How the Framework Detects Service Mode
+### 2. 🔍How the Framework Detects Service Mode
 
 In the file `D2Bridge.Util.pas`, the function `IsRunningAsService` determines whether the application is running as a Windows service by combining two conditions:
 
@@ -69,7 +71,7 @@ end;
 ```
 ---
 
-3. ### 🔄Changes in Server Behavior
+### 3. 🔄Changes in Server Behavior
 
 In `D2Bridge.ServerControllerBase.pas`, the method `CheckNeedConsole` uses the result returned by `IsRunningAsService`.
 ```pascal
@@ -96,7 +98,7 @@ Specifically:
 
 ---
 
-4. ### 📂Configuring Server Port and Name Without a Console
+### 4. 📂Configuring Server Port and Name Without a Console
 
 When running without a console, the server reads configuration values directly from a file named `Config.ini`, located in the same directory as the executable file.
 
@@ -121,8 +123,10 @@ Server Port=8888
 Server Name=YourServerName
 ```
 > 💡 Replace `8888` with your desired port number and `YourServerName` with your preferred server name.
+
 ---
-5. ### 💻Registering the Application as a Windows Service
+
+### 5. 💻Registering the Application as a Windows Service
 
 > 🚨 **Prerequisite:** Run Command Prompt (`cmd`) or PowerShell as **Administrator**.
 
@@ -170,7 +174,8 @@ NSSM (Non-Sucking Service Manager) is a free tool that provides automatic restar
   nssm remove ServiceName confirm
   ```
 ---
-6. ### 🚀Full Service Initialization Flow
+
+### 6. 🚀Full Service Initialization Flow
 
 1. Windows starts the service in Session 0 without an interactive desktop.
 
@@ -192,7 +197,7 @@ NSSM (Non-Sucking Service Manager) is a free tool that provides automatic restar
 
 10. The internal loop keeps the process alive while the server is running.
 ---
-7. ### ⚠️Important Notes
+### 7. ⚠️Important Notes
 
 * The `.dpr` file **does not require any modification**.
 

--- a/Beta/DOC/D2Bridge_as_a_Service_With_NSSM_EN.md
+++ b/Beta/DOC/D2Bridge_as_a_Service_With_NSSM_EN.md
@@ -1,0 +1,85 @@
+# 🌐 Installing D2Bridge Delphi applications as a Windows service with NSSM
+
+## 📑 Table of Contents
+
+* [Basic Information](#-basic-information)
+    * [❓¿What is NSSM?](#what-is-nssm)
+    * [Advantages of NSSM](#advantages-of-nssm)
+* [Installation and Configuration](#-installation-and-configuration)
+    * [Installing NSSM](#installing-nssm)
+    * [Verifying if NSSM is installed correctly](#verifying-if-nssm-is-installed-correctly)
+    * [Run D2Bridge Web App](#run-d2bridge-web-app)
+---
+
+## 📋 Basic Information
+
+### ❓¿What is NSSM?
+
+NSSM, or Non-Sucking Service Manager, is an open-source utility for managing services in Windows operating systems. It allows you to run any application as a Windows service, offering features such as automatic restart if the service fails, and includes a graphical service installer and uninstaller. NSSM is compatible with Windows 2000 and later versions, including Windows 7, 8, and 10. It simplifies service management compared to the basic Windows Services utility, offering additional options for better control.
+
+### Advantages of NSSM
+
+* **Non-Sucking Service Manager (NSSM)** is a free tool that allows you to convert almost any application or executable, including console applications, into a Windows service.
+
+* It is responsible for **monitoring and restarting** the application if it stops unexpectedly.
+
+* Log events in the **Event Viewer** for diagnostics.
+
+* It offers a simple graphical interface for configuring parameters such as working directory, arguments, and automatic recovery.
+
+* Backward compatibility with previous versions of Windows (Windows Server 2008 R2/Windows 7 and earlier, although not tested).
+
+* Ideal for Windows Server
+
+* Automatic startup on boot without login (The user who created the startup entry does not need to log in for it to start).
+
+* Run both binaries as Services.
+
+* Independent (no dependency on Node.js)
+
+---
+
+## 🚀 Installation and Configuration
+
+### Installing NSSM
+
+Please download and extract [NSSM](https://github.com/dkxce/NSSM/releases/download/v2.25/NSSM_v2.25.zip), selecting the appropriate architecture for your Windows system (if x86, use the contents of the win32 folder; if x64, use the contents of the win64 folder). It is also good practice to move the NSSM binary to the `Program Files\NSSM` directory (NSSM, once started as a service, cannot be moved from its original directory; therefore, it is best to save it in Program Files) on your installation drive (usually the `C:` drive). It is also recommended to add the path (such as `C:\Program Files\NSSM`) to the `PATH environment variable`.
+
+### Verifying if NSSM is installed correctly
+
+If you have done everything correctly, the folder I'm using the `C:\Program Files\NSSM` (in this example `C:` drive, but you can use any drive where you installed Windows or any path you prefer) should only contain the **nssm.exe** file.
+
+We will use `C:\Program Files\NSSM` in this example.
+
+Open the Command Prompt and run `nssm`. If you see a help page, you are ready to proceed to the next step.
+
+### Run D2Bridge Web App
+
+Copy the D2Bridge application to `D:\RCSystem\WebApp\WebAppCoopABC.exe` (or anywhere you like, just make sure it doesn't change after installing the service). Now return to the command prompt. 
+
+We will use `D:\RCSystem\WebApp\WebAppCoopABC.exe` in this example. 
+```Bash
+nssm install “webappcoopabc” “D:\RCSystem\WebApp\WebAppCoopABC.exe”
+```
+### Note:
+
+> - You can change the service name to WebAppCoopabc.
+>
+> - You can change D:\RCSystem\WebApp\WebAppCoopABC.exe to the location where
+>
+> - you placed the D2Bridge application
+
+### Command templates:
+
+The command template in case you only want to copy, paste, and edit.
+
+#### Installing service
+```Bash
+nssm install <Desired D2Bridge Service Name> <WebApp Route>
+```
+#### Start services
+After successful installation of the services, they must be started.
+```Bash
+nssm start <D2Bridge Service name>
+```
+Ready!

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
+# 🌐D2Bridge Framework
 <div align="center">
-<strong style="font-size:28px;">D2Bridge Framework</strong>
-
-<br>
-
+ 
 ![D2Bridge Logo](/assets/LogoD2BridgeTransp.png)
 
 [![GitHub stars](https://img.shields.io/github/stars/d2bridge/d2bridgeframework?style=social)](https://github.com/d2bridge/d2bridgeframework/stargazers)
@@ -79,10 +77,27 @@ This Framework was designed to compile your Delphi project on the Web, all proce
 - First, close all open Delphi instances.
 - To install the full D2Bridge Framework and the D2Bridge Wizard, run: Wizard/InstallD2BridgeWizard.exe 
 
-
 ### Lazarus (Windows only)
 - First, close all open Lazarus instances.
 - To install the full D2Bridge Framework and the D2Bridge Wizard, compile and install the package: Wizard/Package/d2bridgeframeworkwizard.lpk 
+
+---
+
+## 📚 Documentación y Manuales
+
+- 📖 [D2Bridge Framework - Unofficial Encyclopedia (EN)](./Beta/DOC/D2Bridge_EN.md)
+- 📖 [D2Bridge Framework - Nieoficjalna Encyklopedia (PL)](./Beta/DOC/D2Bridge_PL.md)
+
+- 📑 Manuales en PDF:
+  - [D2Bridge Ecosystem](./Beta/DOC/D2Bridge%20Ecosystem.pdf)
+  - [Form Rendering Lifecycle](./Beta/DOC/Form%20Rendering%20Lifecycle.pdf)
+  - [Update Control Event](./Beta/DOC/Update%20Control%20Event.pdf)
+  - [Using D2Bridge Resource Monitor](./Beta/DOC/D2Bridge_Resource_Monitor.md)
+  - [Using D2Bridge Windows Service](./Beta/DOC/D2Bridge_Windows_Service.md)
+  - [D2Bridge as a Service With NSSM EN](./Beta/DOC/D2Bridge_as_a_Service_With_NSSM_EN.md)
+  - [Tags](./Beta/DOC/Tags.pdf)
+  - [Variables](./Beta/DOC/Variables.pdf)
+  - [CallBack](./Beta/DOC/CallBack.pdf)
 
 ---
 
@@ -93,7 +108,7 @@ Use the **Discord channel** for community support.
 
 ## 📜 License
 
-***D2Bridge Framework Content***
+**_D2Bridge Framework Content_**
 
   **Author:** Talis Jonatas Gomes<br>
   **Email:** talisjonatas@me.com
@@ -136,7 +151,7 @@ Use the **Discord channel** for community support.
 ---
 
 ## 🤝 Contributing
-***Contributions are welcome!***
+**_Contributions are welcome!_**
 
 D2Bridge Framework is an Open Source tool and we do not have any source of income so your donation is very welcome to maintain the project
 
@@ -145,4 +160,4 @@ D2Bridge Framework is an Open Source tool and we do not have any source of incom
 We will be immensely grateful for your collaboration, and you can be sure that we will always do our best to ensure you have the best Delphi Web experience with D2Bridge Framework
 
 God bless you<br>
-Talis Jonatas Gomes
+**_Talis Jonatas Gomes_**

--- a/README.md
+++ b/README.md
@@ -85,16 +85,16 @@ This Framework was designed to compile your Delphi project on the Web, all proce
 
 ## 📚 Documentación y Manuales
 
-- 📖 [D2Bridge Framework - Unofficial Encyclopedia (EN)](./Beta/DOC/D2Bridge_EN.md)
-- 📖 [D2Bridge Framework - Nieoficjalna Encyklopedia (PL)](./Beta/DOC/D2Bridge_PL.md)
+- 📖[D2Bridge Framework - Unofficial Encyclopedia (EN)](./Beta/DOC/D2Bridge_EN.md)
+- 📖[D2Bridge Framework - Nieoficjalna Encyklopedia (PL)](./Beta/DOC/D2Bridge_PL.md)
+- 📊[Using D2Bridge Resource Monitor](./Beta/DOC/D2Bridge_Resource_Monitor.md)
+- ⚙️[Using D2Bridge Windows Service](./Beta/DOC/D2Bridge_Windows_Service.md)
+- 🚀[D2Bridge as a Service With NSSM EN](./Beta/DOC/D2Bridge_as_a_Service_With_NSSM_EN.md)
 
 - 📑 Manuales en PDF:
   - [D2Bridge Ecosystem](./Beta/DOC/D2Bridge%20Ecosystem.pdf)
   - [Form Rendering Lifecycle](./Beta/DOC/Form%20Rendering%20Lifecycle.pdf)
   - [Update Control Event](./Beta/DOC/Update%20Control%20Event.pdf)
-  - [Using D2Bridge Resource Monitor](./Beta/DOC/D2Bridge_Resource_Monitor.md)
-  - [Using D2Bridge Windows Service](./Beta/DOC/D2Bridge_Windows_Service.md)
-  - [D2Bridge as a Service With NSSM EN](./Beta/DOC/D2Bridge_as_a_Service_With_NSSM_EN.md)
   - [Tags](./Beta/DOC/Tags.pdf)
   - [Variables](./Beta/DOC/Variables.pdf)
   - [CallBack](./Beta/DOC/CallBack.pdf)


### PR DESCRIPTION
## Description
This PR improves the project documentation by migrating an existing PDF manual to Markdown and adding a completely new deployment guide. 

## Changes
* **Resource Monitor Manual:** Converted `Using D2Bridge Resource Monitor.pdf` into a clean, scannable Markdown file (`.md`). Added an interactive Table of Contents and emojis to improve readability and navigation.
* **Using D2Bridge Windows Service:** Converted `Using D2Bridge Windows Service.pdf` into a clean, scannable Markdown file (`.md`). Added an interactive Table of Contents and emojis to improve readability and navigation, D2Bridge framework natively handles Windows Service detection (Session 0) and how to deploy the executable using `sc.exe` or `NSSM`.

## Motivation
Moving documentation from binary PDF formats to Markdown allows for better version control tracking, easier updates by the community, and seamless reading directly within GitHub/GitLab.