### PR TITLE
Ajustes no metodo GetProfilePhotoAsBase64 

### DIFF
--- a/Beta/D2Bridge Framework/D2Bridge.API.Auth.Microsoft.pas
+++ b/Beta/D2Bridge Framework/D2Bridge.API.Auth.Microsoft.pas
@@ -235,6 +235,7 @@ begin
     vparams.Add('client_id='    + Config.ClientID);
     vparams.Add('scope='        + MicrosoftAuthScope);
     vparams.Add('redirect_uri=' + vRedirectURI);
+    vparams.Add('client_secret=' + Config.ClientSecret);
     vparams.Add('grant_type=authorization_code');
 
 {$IFNDEF FPC}

--- a/Beta/D2Bridge Framework/D2Bridge.API.Auth.Microsoft.pas
+++ b/Beta/D2Bridge Framework/D2Bridge.API.Auth.Microsoft.pas
@@ -143,7 +143,9 @@ begin
 
     Response := TStringStream.Create('');
 
-    HTTPClient.Get('https://graph.microsoft.com/v1.0/me/photo/$value', Response);
+    HTTPClient.HTTPMethod('GET', 'https://graph.microsoft.com/v1.0/me/photo/$value', Response, []);
+
+    //HTTPClient.Get('https://graph.microsoft.com/v1.0/me/photo/$value', Response);
 
     vResponseStatusCode:= HTTPClient.ResponseStatusCode;
     vResponseContent:= Response;
@@ -169,6 +171,8 @@ begin
       Base64Stream.Position := 0;
 
       Result := 'data:image/jpeg;base64,' + Base64Stream.DataString;
+      Encoder.Free;
+
     end
     else
     begin
@@ -178,9 +182,6 @@ begin
     HTTPClient.Free;
     PhotoStream.Free;
     Base64Stream.Free;
-{$IFDEF FPC}
-    Encoder.Free;
-{$ENDIF}
   end;
 end;
 


### PR DESCRIPTION
[Ajustes no metodo GetProfilePhotoAsBase64 no lazarus, por o mesmo (https://github.com/d2bridge/d2bridgeframework/commit/0448219f17bc48a673f9aa22876cb5fa0213d8ae) 

…ava dando acession violation porque o objeto não estava criado Encoder: TBase64EncodingStream, esse acontece quando logada no conta da microsoft e nao tem foto.