### PR TITLE
Fix GetProfilePhotoAsBase64 no Beta (Encoder.Free Delphi)

### DIFF
--- a/Beta/D2Bridge Framework/D2Bridge.API.Auth.Microsoft.pas
+++ b/Beta/D2Bridge Framework/D2Bridge.API.Auth.Microsoft.pas
@@ -162,16 +162,20 @@ begin
   {$ELSE}
       EncodeStream(PhotoStream, Base64Stream);
   {$ENDIF}
-{$ELSE}
-      Encoder:= TBase64EncodingStream.Create(Base64Stream);
-      Encoder.CopyFrom(PhotoStream, PhotoStream.Size);
-      Encoder.Flush;
-{$ENDIF}
-
       Base64Stream.Position := 0;
-
       Result := 'data:image/jpeg;base64,' + Base64Stream.DataString;
-      Encoder.Free;
+{$ELSE}
+      Encoder := nil;
+      try
+        Encoder := TBase64EncodingStream.Create(Base64Stream);
+        Encoder.CopyFrom(PhotoStream, PhotoStream.Size);
+        Encoder.Flush;
+        Base64Stream.Position := 0;
+        Result := 'data:image/jpeg;base64,' + Base64Stream.DataString;
+      finally
+        Encoder.Free;
+      end;
+{$ENDIF}
 
     end
     else


### PR DESCRIPTION
## Summary
- Corrige `GetProfilePhotoAsBase64` no **Beta** para que `Encoder.Free` fique apenas no bloco `{ FPC}`, com `try/finally`.
- No Delphi o objeto `Encoder` nao e declarado/criado; o `Free` fora do IFDEF quebrava a compilacao apos o ajuste do 
